### PR TITLE
fix: remove redundant global declarations

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,10 +1,4 @@
-const SUPABASE_URL = 'https://dtplarkoscdbmqbondri.supabase.co';
-const SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImR0cGxhcmtvc2NkYm1xYm9uZHJpIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTY3MzQ0NDYsImV4cCI6MjA3MjMxMDQ0Nn0.QKwzKbookhedLVK1kxjCVMVMUbz7GWt-';
-
-const supabase = window.supabase.createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
-const { useState, useEffect, useCallback, useRef } = React;
-
-// EventFeed Component
+// Using Supabase client and React hooks defined in components.js
 const EventFeed = ({ user }) => {
     const [events, setEvents] = useState([]);
     const [loading, setLoading] = useState(true);


### PR DESCRIPTION
## Summary
- avoid redeclaration errors by removing duplicate Supabase and React hook definitions

## Testing
- `npm test` *(fails: Missing script: "test"?)*
- `npm run lint` *(fails: Missing script: "lint"?)*

------
https://chatgpt.com/codex/tasks/task_e_68c350720eb8832c813d9bea40a2d87d